### PR TITLE
🐛 fix : Fix nickname error

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -20,15 +20,17 @@ class CommentController extends Controller
         $request->validate([
             'text' => 'required|string',
             'author_id' => 'required',
-            'nickname' => 'required|string',
+            'nickname' => 'required',
         ]);
 
-        $comment = Comment::create([
+        $comment = new Comment([
             'text' => $request->text,
             'author_id' => $request->author_id,
             'nickname' => $request->nickname,
             'post_id' => $community,
         ]);
+
+        $comment->save();
 
         return response()->json(['comment' => $comment], 201);
     }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -11,7 +11,7 @@ class Comment extends Model
 
     protected $table = 'comments';
 
-    protected $fillable = ['post_id', 'author_id', 'text'];
+    protected $fillable = ['post_id', 'author_id', 'nickname', 'text'];
 
     public function post()
     {


### PR DESCRIPTION
`CommentController`에서 `store` 메서드를 호출할 때, `nickname`이 정상적으로 저장되지 않는 에러 수정